### PR TITLE
Add WiFi configuration endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ansible.log
 .ansible_vault_pass
 host_vars/secrets.yml
 group_vars/secrets.yml
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ansible-pull -U https://github.com/oduvan/webquiz-ansible.git site.yml
 - Sets up Python virtual environment with webquiz package
 - Configures exfat partition mounting at /mnt/data
 - Installs hotspot management scripts and services
+- Runs a WiFi configuration endpoint (see below)
 - **Configures automatic ansible-pull service that runs:**
   - 5 minutes after boot
   - Every 30 minutes thereafter
@@ -101,6 +102,30 @@ echo "new-branch-name" | sudo tee /mnt/data/ansible-branch
 ```
 
 The next ansible-pull run will use the new branch.
+
+## WiFi Configuration Endpoint
+
+The Pi runs a small HTTP endpoint (`wifi-config-server`, a Python/aiohttp
+service) that lets you save WiFi networks and switch the device onto one without
+hand-editing files. When connected to the Pi's hotspot, open:
+
+```
+http://10.42.0.1:8082/
+```
+
+- **Saved networks** are stored as individual files in `/mnt/data/wifi/`, in the
+  same format as [`files/wifi.conf.example`](files/wifi.conf.example)
+  (`SSID`, `PASSWORD`, optional static-IP fields).
+- **Activating** a network connects to it immediately via NetworkManager and, on
+  success, copies it to the active config `/mnt/data/wifi.conf` (read at boot by
+  `start-hotspot.sh`), so the choice persists across reboots. The active config
+  is only changed on a successful connection.
+- **Access password**: saving, activating and deleting require the WebQuiz admin
+  key (`admin.master_key` in `/mnt/data/webquiz/server.conf`).
+
+> Note: activating a network switches `wlan0` from hotspot mode to client mode.
+> If the target network is unreachable you may lose the hotspot connection;
+> rebooting restores the previously active configuration.
 
 ## Image Pre-configuration
 

--- a/files/scripts/wifi-activate.sh
+++ b/files/scripts/wifi-activate.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# wifi-activate.sh - Activate a saved WiFi network configuration.
+#
+# This script is intentionally SEPARATE from start-hotspot.sh. It is invoked
+# (typically by the wifi-config-server) to switch the Pi onto a saved WiFi
+# network on demand:
+#
+#   1. Source the given saved config file (bash env-var format, same fields as
+#      files/wifi.conf.example: SSID, PASSWORD, optional IPADDR/GATEWAY/DNS/
+#      IPPREFIX).
+#   2. Attempt to connect with nmcli (DHCP, or static IP when all of
+#      IPADDR/GATEWAY/DNS are provided).
+#   3. On success, copy the saved config to the active location
+#      (/mnt/data/wifi.conf) so the choice persists across reboots, then exit 0.
+#   4. On failure, leave the current active config untouched and exit non-zero.
+#
+# Usage: wifi-activate.sh <path-to-saved-config>
+
+set -u
+
+ACTIVE_CONF="${ACTIVE_CONF:-/mnt/data/wifi.conf}"
+IFACE="${IFACE:-wlan0}"
+
+log()  { echo "[INFO] $*"; }
+warn() { echo "[WARN] $*"; }
+err()  { echo "[ERROR] $*"; }
+
+CONFIG_PATH="${1:-}"
+
+if [ -z "$CONFIG_PATH" ]; then
+  err "Usage: $0 <path-to-saved-config>"
+  exit 2
+fi
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  err "Config file not found: $CONFIG_PATH"
+  exit 2
+fi
+
+# Load the saved configuration.
+# shellcheck disable=SC1090
+source "$CONFIG_PATH"
+
+if [ -z "${SSID:-}" ] || [ -z "${PASSWORD:-}" ]; then
+  err "Config '$CONFIG_PATH' is missing SSID or PASSWORD"
+  exit 2
+fi
+
+log "Activating WiFi network '$SSID' on $IFACE"
+
+# Determine whether a full static IP configuration was supplied.
+have_static=0
+if [ -n "${IPADDR:-}" ] && [ -n "${GATEWAY:-}" ] && [ -n "${DNS:-}" ]; then
+  have_static=1
+  log "Static IP requested: $IPADDR (gw: $GATEWAY, dns: $DNS)"
+else
+  log "No full static IP config found; will use DHCP"
+fi
+
+# Start from a clean connection profile with the same name.
+nmcli -t -f NAME connection show | grep -Fxq "$SSID" && \
+  nmcli connection delete "$SSID" >/dev/null 2>&1
+
+# Create the connection by connecting once (this also stores the PSK).
+if ! nmcli dev wifi connect "$SSID" password "$PASSWORD" ifname "$IFACE" name "$SSID" >/dev/null 2>&1; then
+  err "WiFi connect failed for SSID '$SSID'"
+  nmcli connection delete "$SSID" >/dev/null 2>&1 || true
+  exit 1
+fi
+
+# Apply static or DHCP addressing as requested.
+if [ "$have_static" -eq 1 ]; then
+  ipprefix="${IPPREFIX:-24}"
+  nmcli connection modify "$SSID" \
+    ipv4.addresses "$IPADDR/$ipprefix" \
+    ipv4.gateway "$GATEWAY" \
+    ipv4.dns "$DNS" \
+    ipv4.method manual \
+    ipv6.method ignore >/dev/null 2>&1 || warn "Failed to set static IPv4"
+else
+  nmcli connection modify "$SSID" \
+    ipv4.method auto \
+    ipv6.method ignore >/dev/null 2>&1 || warn "Failed to set DHCP"
+fi
+
+# Re-activate with the final addressing settings.
+if ! nmcli connection up "$SSID" >/dev/null 2>&1; then
+  err "Failed to activate connection '$SSID'"
+  exit 1
+fi
+
+log "WiFi connection '$SSID' established successfully"
+
+# Persist the choice as the active config (only after a successful connect).
+if cp "$CONFIG_PATH" "$ACTIVE_CONF"; then
+  log "Saved '$CONFIG_PATH' as active config $ACTIVE_CONF"
+else
+  warn "Connected, but failed to copy config to $ACTIVE_CONF"
+fi
+
+exit 0

--- a/files/scripts/wifi-config-server.py
+++ b/files/scripts/wifi-config-server.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""WiFi configuration endpoint.
+
+A small aiohttp server that lets an operator (typically connected to the Pi's
+WiFi hotspot) save WiFi networks and activate one on demand.
+
+Design notes:
+  * Saved networks live as individual files in WIFI_DIR (/mnt/data/wifi/), each
+    in the same bash env-var format used by files/wifi.conf.example
+    (SSID, PASSWORD, optional IPADDR/GATEWAY/DNS/IPPREFIX).
+  * The *active* network is the existing /mnt/data/wifi.conf consumed at boot by
+    start-hotspot.sh. Activation is delegated to the separate wifi-activate.sh
+    script, which connects via nmcli and, on success, copies the saved file to
+    the active location.
+  * Every mutating request is authenticated against the WebQuiz admin master_key
+    read from /mnt/data/webquiz/server.conf.
+
+Security: saved files are `source`d by bash, so all values are strictly
+validated and single-quote escaped to avoid command injection.
+"""
+
+import asyncio
+import hmac
+import html
+import os
+import re
+import shlex
+
+from aiohttp import web
+
+# --- Configuration (overridable via environment) ---------------------------
+HOST = os.environ.get("WIFI_CONFIG_HOST", "0.0.0.0")
+PORT = int(os.environ.get("WIFI_CONFIG_PORT", "8082"))
+WIFI_DIR = os.environ.get("WIFI_DIR", "/mnt/data/wifi")
+ACTIVE_CONF = os.environ.get("ACTIVE_CONF", "/mnt/data/wifi.conf")
+WEBQUIZ_CONF = os.environ.get("WEBQUIZ_CONF", "/mnt/data/webquiz/server.conf")
+ACTIVATE_SCRIPT = os.environ.get(
+    "WIFI_ACTIVATE_SCRIPT", "/usr/local/bin/wifi-activate.sh"
+)
+
+# --- Validation rules ------------------------------------------------------
+NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+# IEEE 802.11 SSID: 1-32 octets. WPA2 PSK: 8-63 chars. We also forbid newlines
+# and NUL everywhere because the values are written into a bash-sourced file.
+SSID_MAX = 32
+PASSWORD_MAX = 63
+IP_RE = re.compile(r"^[0-9.]{1,15}$")
+PREFIX_RE = re.compile(r"^[0-9]{1,2}$")
+
+
+def read_master_key():
+    """Read admin.master_key from the WebQuiz YAML config.
+
+    Uses PyYAML when available (webquiz depends on it) and falls back to a
+    minimal line-based parse so the endpoint still works if PyYAML is absent.
+    Returns the key string, or None if it cannot be determined.
+    """
+    try:
+        with open(WEBQUIZ_CONF, "r") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+        admin = data.get("admin") or {}
+        key = admin.get("master_key")
+        if key is not None:
+            return str(key)
+    except Exception:
+        pass
+
+    # Fallback: find `master_key:` inside the `admin:` block.
+    in_admin = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if re.match(r"^admin\s*:", line):
+            in_admin = True
+            continue
+        # A new top-level (non-indented) key ends the admin block.
+        if in_admin and re.match(r"^\S", line) and not re.match(r"^admin\s*:", line):
+            in_admin = False
+        if in_admin:
+            m = re.match(r"^\s*master_key\s*:\s*(.+?)\s*$", line)
+            if m:
+                val = m.group(1)
+                # Strip surrounding quotes and trailing inline comment.
+                if val and val[0] in "\"'":
+                    quote = val[0]
+                    end = val.find(quote, 1)
+                    if end != -1:
+                        return val[1:end]
+                val = val.split("#", 1)[0].strip()
+                return val
+    return None
+
+
+def check_password(supplied):
+    """Constant-time comparison of the supplied password to the master key."""
+    key = read_master_key()
+    if not key or supplied is None:
+        return False
+    return hmac.compare_digest(str(supplied), str(key))
+
+
+def list_networks():
+    """Return a sorted list of saved network names (without .conf)."""
+    try:
+        names = [
+            fn[:-5]
+            for fn in os.listdir(WIFI_DIR)
+            if fn.endswith(".conf") and os.path.isfile(os.path.join(WIFI_DIR, fn))
+        ]
+    except OSError:
+        names = []
+    return sorted(names)
+
+
+def active_matches(name):
+    """True if the saved network <name> is byte-identical to the active conf."""
+    path = os.path.join(WIFI_DIR, name + ".conf")
+    try:
+        with open(path, "rb") as a, open(ACTIVE_CONF, "rb") as b:
+            return a.read() == b.read()
+    except OSError:
+        return False
+
+
+def _clean(value):
+    """Reject values containing characters unsafe for a bash-sourced file."""
+    if value is None:
+        return ""
+    value = value.strip()
+    if "\n" in value or "\r" in value or "\x00" in value:
+        raise ValueError("control characters are not allowed")
+    return value
+
+
+def build_config(form):
+    """Validate form fields and render the bash env-var config file contents.
+
+    Raises ValueError with a human-readable message on invalid input.
+    """
+    name = _clean(form.get("name"))
+    if not NAME_RE.match(name):
+        raise ValueError(
+            "Name must be 1-64 chars of letters, digits, dot, dash or underscore."
+        )
+
+    ssid = _clean(form.get("ssid"))
+    if not ssid or len(ssid) > SSID_MAX:
+        raise ValueError("SSID is required and must be at most 32 characters.")
+
+    password = _clean(form.get("password"))
+    if not password or not (8 <= len(password) <= PASSWORD_MAX):
+        raise ValueError("Password is required and must be 8-63 characters.")
+
+    lines = [
+        "# Saved WiFi network: %s" % name,
+        "# Generated by wifi-config-server. Format matches wifi.conf.example.",
+        "SSID=%s" % shlex.quote(ssid),
+        "PASSWORD=%s" % shlex.quote(password),
+    ]
+
+    # Optional static IP block (only emitted when all three are present).
+    ipaddr = _clean(form.get("ipaddr"))
+    gateway = _clean(form.get("gateway"))
+    dns = _clean(form.get("dns"))
+    prefix = _clean(form.get("ipprefix"))
+    if ipaddr or gateway or dns:
+        for label, val in (("IPADDR", ipaddr), ("GATEWAY", gateway), ("DNS", dns)):
+            if not IP_RE.match(val):
+                raise ValueError(
+                    "For a static IP, %s must be a valid IPv4 address." % label
+                )
+        lines.append("IPADDR=%s" % shlex.quote(ipaddr))
+        lines.append("GATEWAY=%s" % shlex.quote(gateway))
+        lines.append("DNS=%s" % shlex.quote(dns))
+        if prefix:
+            if not PREFIX_RE.match(prefix) or not (0 <= int(prefix) <= 32):
+                raise ValueError("IP prefix must be a number between 0 and 32.")
+            lines.append("IPPREFIX=%s" % shlex.quote(prefix))
+
+    return name, "\n".join(lines) + "\n"
+
+
+# --- HTML rendering --------------------------------------------------------
+PAGE_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WiFi Configuration</title>
+<style>
+  body {{ font-family: sans-serif; max-width: 640px; margin: 1.5rem auto;
+         padding: 0 1rem; color: #222; }}
+  h1 {{ font-size: 1.4rem; }}
+  fieldset {{ border: 1px solid #ccc; border-radius: 8px; margin-bottom: 1rem; }}
+  label {{ display: block; margin: .5rem 0 .15rem; font-size: .9rem; }}
+  input {{ width: 100%; padding: .45rem; box-sizing: border-box;
+          border: 1px solid #bbb; border-radius: 6px; }}
+  button {{ padding: .45rem .8rem; border: 0; border-radius: 6px;
+           background: #2563eb; color: #fff; cursor: pointer; }}
+  button.danger {{ background: #dc2626; }}
+  .net {{ display: flex; align-items: center; justify-content: space-between;
+         padding: .5rem 0; border-bottom: 1px solid #eee; }}
+  .net form {{ display: inline; margin: 0 0 0 .4rem; }}
+  .active {{ color: #16a34a; font-weight: bold; }}
+  .msg {{ padding: .6rem .8rem; border-radius: 6px; margin-bottom: 1rem; }}
+  .msg.ok {{ background: #dcfce7; color: #166534; }}
+  .msg.err {{ background: #fee2e2; color: #991b1b; }}
+  .hint {{ color: #666; font-size: .8rem; }}
+</style>
+</head>
+<body>
+<h1>WiFi Configuration</h1>
+{message}
+<h2>Saved networks</h2>
+<div>{networks}</div>
+<p class="hint">Activating a network switches this device off its hotspot and
+onto the selected WiFi. If the connection fails you may lose access; the active
+network only changes on a successful connection.</p>
+
+<h2>Add a network</h2>
+<form method="post" action="/save">
+  <fieldset>
+    <legend>Network</legend>
+    <label>Name (identifier for this saved entry)</label>
+    <input name="name" required pattern="[A-Za-z0-9._-]{{1,64}}">
+    <label>SSID (WiFi name)</label>
+    <input name="ssid" required maxlength="32">
+    <label>Password</label>
+    <input name="password" required minlength="8" maxlength="63">
+  </fieldset>
+  <fieldset>
+    <legend>Static IP (optional)</legend>
+    <label>IP address</label><input name="ipaddr">
+    <label>Gateway</label><input name="gateway">
+    <label>DNS</label><input name="dns">
+    <label>Prefix (default 24)</label><input name="ipprefix">
+  </fieldset>
+  <fieldset>
+    <legend>Access</legend>
+    <label>Access password (WebQuiz master key)</label>
+    <input name="access_password" type="password" required>
+  </fieldset>
+  <button type="submit">Save network</button>
+</form>
+</body>
+</html>
+"""
+
+
+def render_network_row(name):
+    label = html.escape(name)
+    if active_matches(name):
+        label += ' <span class="active">(active)</span>'
+    return (
+        '<div class="net"><span>{label}</span><span>'
+        '<form method="post" action="/activate">'
+        '<input type="hidden" name="name" value="{name}">'
+        '<input type="password" name="access_password" placeholder="access password" required>'
+        '<button type="submit">Activate</button></form>'
+        '<form method="post" action="/delete">'
+        '<input type="hidden" name="name" value="{name}">'
+        '<input type="password" name="access_password" placeholder="access password" required>'
+        '<button type="submit" class="danger">Delete</button></form>'
+        "</span></div>"
+    ).format(label=label, name=html.escape(name))
+
+
+def render_page(message_html=""):
+    rows = [render_network_row(n) for n in list_networks()]
+    networks = "".join(rows) if rows else "<p>No saved networks yet.</p>"
+    return PAGE_TEMPLATE.format(message=message_html, networks=networks)
+
+
+def msg(kind, text):
+    return '<div class="msg {kind}">{text}</div>'.format(
+        kind=kind, text=html.escape(text)
+    )
+
+
+# --- Handlers --------------------------------------------------------------
+async def handle_index(request):
+    return web.Response(text=render_page(), content_type="text/html")
+
+
+async def handle_save(request):
+    form = await request.post()
+    if not check_password(form.get("access_password")):
+        return web.Response(
+            text=render_page(msg("err", "Invalid access password.")),
+            content_type="text/html",
+            status=403,
+        )
+    try:
+        name, contents = build_config(form)
+    except ValueError as exc:
+        return web.Response(
+            text=render_page(msg("err", str(exc))),
+            content_type="text/html",
+            status=400,
+        )
+
+    os.makedirs(WIFI_DIR, exist_ok=True)
+    path = os.path.join(WIFI_DIR, name + ".conf")
+    with open(path, "w") as fh:
+        fh.write(contents)
+
+    return web.Response(
+        text=render_page(msg("ok", "Saved network '%s'." % name)),
+        content_type="text/html",
+    )
+
+
+async def handle_activate(request):
+    form = await request.post()
+    if not check_password(form.get("access_password")):
+        return web.Response(
+            text=render_page(msg("err", "Invalid access password.")),
+            content_type="text/html",
+            status=403,
+        )
+    name = _clean(form.get("name"))
+    if not NAME_RE.match(name):
+        return web.Response(
+            text=render_page(msg("err", "Invalid network name.")),
+            content_type="text/html",
+            status=400,
+        )
+    path = os.path.join(WIFI_DIR, name + ".conf")
+    if not os.path.isfile(path):
+        return web.Response(
+            text=render_page(msg("err", "No such saved network.")),
+            content_type="text/html",
+            status=404,
+        )
+
+    proc = await asyncio.create_subprocess_exec(
+        ACTIVATE_SCRIPT,
+        path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    output = (out or b"").decode("utf-8", "replace")
+
+    if proc.returncode == 0:
+        text = render_page(msg("ok", "Activated '%s'." % name))
+        status = 200
+    else:
+        text = render_page(
+            msg("err", "Failed to activate '%s'. %s" % (name, output.strip()))
+        )
+        status = 502
+    return web.Response(text=text, content_type="text/html", status=status)
+
+
+async def handle_delete(request):
+    form = await request.post()
+    if not check_password(form.get("access_password")):
+        return web.Response(
+            text=render_page(msg("err", "Invalid access password.")),
+            content_type="text/html",
+            status=403,
+        )
+    name = _clean(form.get("name"))
+    if not NAME_RE.match(name):
+        return web.Response(
+            text=render_page(msg("err", "Invalid network name.")),
+            content_type="text/html",
+            status=400,
+        )
+    path = os.path.join(WIFI_DIR, name + ".conf")
+    try:
+        os.remove(path)
+    except OSError:
+        return web.Response(
+            text=render_page(msg("err", "No such saved network.")),
+            content_type="text/html",
+            status=404,
+        )
+    return web.Response(
+        text=render_page(msg("ok", "Deleted '%s'." % name)),
+        content_type="text/html",
+    )
+
+
+def make_app():
+    app = web.Application()
+    app.add_routes(
+        [
+            web.get("/", handle_index),
+            web.post("/save", handle_save),
+            web.post("/activate", handle_activate),
+            web.post("/delete", handle_delete),
+        ]
+    )
+    return app
+
+
+if __name__ == "__main__":
+    os.makedirs(WIFI_DIR, exist_ok=True)
+    web.run_app(make_app(), host=HOST, port=PORT)

--- a/files/systemd/wifi-config-server.service
+++ b/files/systemd/wifi-config-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=WiFi Configuration Endpoint
+Documentation=https://github.com/oduvan/webquiz-ansible
+After=network-online.target NetworkManager.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+# Run with the webquiz venv python, which already provides aiohttp.
+ExecStart=/home/oduvan/venv_webquiz/bin/python /usr/local/bin/wifi-config-server.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/files/wifi.conf.example
+++ b/files/wifi.conf.example
@@ -34,3 +34,6 @@
 # - Interface: wlan0 by default (override with IFACE environment variable)
 # - Hotspot IP: NetworkManager assigns 10.42.0.1/24 automatically
 # - Open Hotspot: Set HOTSPOT_SSID without HOTSPOT_PASSWORD for unsecured network
+# - WiFi endpoint: The wifi-config-server (http://10.42.0.1:8082/) saves networks
+#   in this same format under /mnt/data/wifi/, and copies the chosen one here
+#   (/mnt/data/wifi.conf) when you activate it.

--- a/playbooks/raspberry-pi.yml
+++ b/playbooks/raspberry-pi.yml
@@ -145,6 +145,7 @@
   loop:
     - /mnt/data/webquiz
     - /mnt/data/webfiles
+    - /mnt/data/wifi
 
 - name: Check if webquiz server config exists
   stat:
@@ -174,6 +175,8 @@
     - { src: "../files/scripts/get-branch.sh", dest: "/usr/local/bin/get-branch.sh" }
     - { src: "../files/scripts/create_index_html.py", dest: "/usr/local/bin/create_index_html.py" }
     - { src: "../files/scripts/ansible-pull-wrapper.sh", dest: "/usr/local/bin/ansible-pull-wrapper.sh" }
+    - { src: "../files/scripts/wifi-activate.sh", dest: "/usr/local/bin/wifi-activate.sh" }
+    - { src: "../files/scripts/wifi-config-server.py", dest: "/usr/local/bin/wifi-config-server.py" }
 
 - name: Copy systemd files
   copy:
@@ -187,6 +190,7 @@
     - { src: "../files/systemd/start-hotspot.service", dest: "/etc/systemd/system/start-hotspot.service" }
     - { src: "../files/systemd/ansible-pull.service", dest: "/etc/systemd/system/ansible-pull.service" }
     - { src: "../files/systemd/save-boot-journal.service", dest: "/etc/systemd/system/save-boot-journal.service" }
+    - { src: "../files/systemd/wifi-config-server.service", dest: "/etc/systemd/system/wifi-config-server.service" }
   notify: reload systemd
 
 - name: Copy configuration files
@@ -233,5 +237,14 @@
   systemd:
     name: ansible-pull
     enabled: yes
+    daemon_reload: yes
+
+# The WiFi configuration endpoint is a long-running server, so start it now
+# (and restart it to pick up updates) rather than waiting for the next boot.
+- name: Enable and (re)start wifi-config-server service
+  systemd:
+    name: wifi-config-server
+    enabled: yes
+    state: restarted
     daemon_reload: yes
 


### PR DESCRIPTION
## Summary

Adds a running HTTP endpoint that lets an operator (connected to the Pi's hotspot) save WiFi networks and activate one on demand, without hand-editing files on the SD card. Authentication uses the existing WebQuiz admin `master_key`.

When connected to the Pi's hotspot, open `http://10.42.0.1:8082/`.

## How it works

- **Saved networks** are stored as individual files under `/mnt/data/wifi/`, in the existing `wifi.conf` bash env-var format (`SSID`, `PASSWORD`, optional static-IP fields) defined by `files/wifi.conf.example`.
- **Activating** a network connects immediately via `nmcli` and, **only on success**, copies the saved file to the active config `/mnt/data/wifi.conf` (read at boot by `start-hotspot.sh`), so the choice persists across reboots.
- **Access password**: save / activate / delete require the WebQuiz admin key (`admin.master_key` in `/mnt/data/webquiz/server.conf`), read per request.

## Changes

- **`files/scripts/wifi-config-server.py`** (new) — Python/aiohttp server on `:8082` (binds `0.0.0.0`). Lists, saves, activates and deletes saved networks via a simple HTML UI. Reads the master key with PyYAML (line-based fallback).
- **`files/scripts/wifi-activate.sh`** (new) — separate connect/launch script invoked by the server; runs `nmcli` and copies to the active config on success. `start-hotspot.sh` is left untouched.
- **`files/systemd/wifi-config-server.service`** (new) — runs the server as root (required for `nmcli`) via the webquiz venv python.
- **`playbooks/raspberry-pi.yml`** — creates `/mnt/data/wifi`, deploys the scripts and unit, enables and starts the service.
- **Docs** — `README.md` and `wifi.conf.example` notes; `.gitignore` ignores `__pycache__`.

## Security

Saved files are `source`d by bash, so all values are strictly validated and `shlex.quote`-escaped (verified that an injected SSID such as `a';rm -rf /;'` is stored/sourced as a harmless literal). Network names are restricted to `[A-Za-z0-9._-]`, preventing path traversal. The access password is compared with `hmac.compare_digest`.

## Notes / tradeoffs

- The server runs as root because immediate apply needs `nmcli`; mitigated by master_key auth and strict input validation.
- Activating a network switches `wlan0` from hotspot to client mode — if the target is unreachable the operator may lose the hotspot connection. The active config only changes on a successful connect, so a reboot recovers the prior state. This is surfaced in the UI and README.

## Verification

- `bash -n files/scripts/wifi-activate.sh` and `python3 -m py_compile files/scripts/wifi-config-server.py` pass.
- Playbook YAML parses.
- Exercised the master_key parser, input validation, and shell-escaping logic locally (including injection and path-traversal attempts).

https://claude.ai/code/session_01UZk8RMjP79MwDfT4nce9xa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZk8RMjP79MwDfT4nce9xa)_